### PR TITLE
Update blog_train_algos.py

### DIFF
--- a/blog_train_algos.py
+++ b/blog_train_algos.py
@@ -20,7 +20,7 @@ from gluonts.evaluation.backtest import make_evaluation_predictions, backtest_me
 from gluonts.evaluation import Evaluator
 from gluonts.model.predictor import Predictor
 from gluonts.dataset.common import ListDataset
-from gluonts.trainer import Trainer
+from gluonts.mx.trainer import Trainer
 from gluonts.dataset.multivariate_grouper import MultivariateGrouper
 from smdebug.mxnet import Hook
 


### PR DESCRIPTION
Updated from gluonts.trainer import Trainer to gluonts.mx.trainer import Trainer

*Issue #, if available:* - NA

*Description of changes:*

Upon trying to follow point 8- "Evaluate metrics and select a winning candidate" here - https://github.com/aws-samples/amazon-sagemaker-gluonts-timeseriesforecasting-with-debuggerandexperiments/blob/main/Amazon%20Sagemaker%20GluonTS%20time%20series%20forecasting.ipynb,

one cannot move further because it cannot find the error metrics needed, such as RMSE, MAPE or MSE. 

Attached you will find a screenshot with details. As you can see, the columns related to the experiment variables do no contain 'scalar/MAPE_GLOBAL - Min', 'scalar/RMSE_GLOBAL - Min', nor 'scalar/MAPE_GLOBAL - Min' and then we get an error message - Check screenshots Rep1 and Rep2.

<img width="1040" alt="Rep1" src="https://user-images.githubusercontent.com/86518397/123511667-46733980-d6a0-11eb-8d3a-ad16e14f912b.png">
<img width="1028" alt="Rep2" src="https://user-images.githubusercontent.com/86518397/123511677-5b4fcd00-d6a0-11eb-8e1f-51024a892c5d.png">

Using "from gluonts.mx.trainer import Trainer" instead of "from gluonts.trainer import Trainer" fixes the issue. See fixed1 and fixed2.

<img width="1015" alt="fixed1" src="https://user-images.githubusercontent.com/86518397/123511712-95b96a00-d6a0-11eb-9ec6-55692471cb39.png">
<img width="1006" alt="fixed2" src="https://user-images.githubusercontent.com/86518397/123511715-9c47e180-d6a0-11eb-9e0d-bc7f0af92986.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
